### PR TITLE
Functional version supporting gray images

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You will need to include the binaries into the PATH environment variable:
 
 **If** you use bash:
 ```shell
-tar -C ~/jxl-linux-x86_64-static-v0.6.1 -xzvf ~/Downloads/jxl-linux-x86_64-static-v0.6.1.tar.gz
+tar -C ~ -xzvf ~/Downloads/jxl-linux-x86_64-static-v0.6.1.tar.gz
 echo 'export JXL="$HOME/jxl-linux-x86_64-static-v0.6.1"' >> ~/.bashrc
 echo 'export PATH="$JXL/tools:$PATH"' >> ~/.bashrc
 ```
@@ -78,7 +78,7 @@ Download WebP for [x86_64-linux](https://storage.googleapis.com/downloads.webmpr
 . Then run the following commands
 **if** you use bash:
 ```shell
-tar -C ~/libwebp-1.2.1-linux-x86-64/ -xzvf ~/Downloads/libwebp-1.2.1-linux-x86-64.tar.gz
+tar -C ~ -xzvf ~/Downloads/libwebp-1.2.1-linux-x86-64.tar.gz
 echo 'export WEBP_HOME="$HOME/libwebp-1.2.1-linux-x86-64"' >> ~/.bashrc
 echo 'export PATH="$WEBP_HOME/bin:$PATH"' >> ~/.bashrc
 ```

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Download WebP for [x86_64-linux](https://storage.googleapis.com/downloads.webmpr
 **if** you use bash:
 ```shell
 tar -C ~/libwebp-1.2.1-linux-x86-64/ -xzvf ~/Downloads/libwebp-1.2.1-linux-x86-64.tar.gz
-echo 'export WEBP_HOME="$HOME/libwebp-1.2.1-linux-x86-64/"' >> ~/.bashrc
+echo 'export WEBP_HOME="$HOME/libwebp-1.2.1-linux-x86-64"' >> ~/.bashrc
 echo 'export PATH="$WEBP_HOME/bin:$PATH"' >> ~/.bashrc
 ```
 If you use zshell, switch ~/.bashrc with ~/.zshrc.

--- a/dicom_parser.py
+++ b/dicom_parser.py
@@ -3,6 +3,7 @@
     Extracts the image from the DICOM file (assuming only one frame is present)
     and writes it in the dataset {parameters.DATASET_PATH} in the image format {parameters.LOSSLESS_EXTENSION}.
 """
+# TODO deprecate .tiff generation for multi-frame images (since webp doesn't support more than 1 frame)
 
 import os
 from typing import List, Tuple
@@ -161,8 +162,7 @@ def write_single_frame(img_array: np.ndarray, out_img_path: str) -> np.ndarray:
     """
 
     # Encode and write image to dataset folder
-    assert cv2.imwrite(out_img_path, img_array, params=[cv2.IMWRITE_TIFF_COMPRESSION, 1]) \
-           is True, "Image writing (single frame) failed"
+    assert cv2.imwrite(out_img_path, img_array) is True, "Image writing (single frame) failed"
     # Assert no information loss within the written image
     saved_img_array: np.ndarray = cv2.imread(out_img_path, cv2.IMREAD_UNCHANGED)
     return saved_img_array

--- a/dicom_parser.py
+++ b/dicom_parser.py
@@ -25,6 +25,7 @@ PHOTOMETRIC_INTERPRETATION_TAG = BaseTag(0x0028_0004)  # ColourSpace
 SAMPLES_PER_PIXEL_TAG = BaseTag(0x0028_0002)
 PIXEL_DATA_TAG = BaseTag(0xfeff_00e0)
 PIXEL_DATA_TAG_2 = BaseTag(0x7fe0_0010)
+NUMBER_OF_FRAMES = BaseTag(0x0028_0008)
 
 
 def parse_dcm(filepath: str):
@@ -48,11 +49,22 @@ def parse_dcm(filepath: str):
     samples_per_pixel = file_data[SAMPLES_PER_PIXEL_TAG]
     color_space = file_data[PHOTOMETRIC_INTERPRETATION_TAG]
 
+    single_channel: bool = samples_per_pixel.value == 1
+
     # Read the pixel data
     img_array = file_data.pixel_array
 
+    number_of_frames = file_data.get(NUMBER_OF_FRAMES)
+    if number_of_frames is None:
+        # When the info on # of frames is on the dicom metadata
+        if single_channel and len(img_array.shape) == 3 or len(img_array.shape) == 4:
+            number_of_frames = img_array.shape[0]
+        else:
+            number_of_frames = 1
+
     # Set image path where it will be written on
-    attributes = '_'.join([str(elem.value) for elem in (color_space, samples_per_pixel, bps)])
+    attributes = '_'.join([str(elem) for elem in (color_space.value,
+                                                  samples_per_pixel.value, bps.value, number_of_frames)])
     out_img_path: str = DATASET_PATH + f"{modality.value.replace(' ', '')}_{body_part.value}_{attributes}"
 
     repetition_id = 0
@@ -72,8 +84,6 @@ def parse_dcm(filepath: str):
 
     out_img_path += LOSSLESS_EXTENSION
 
-    single_channel: bool = samples_per_pixel.value == 1
-
     if len(img_array.shape) <= 2 or not single_channel and len(img_array.shape) == 3:
         saved_img_array = write_single_frame(img_array, out_img_path)
     else:
@@ -87,7 +97,6 @@ def parse_dcm(filepath: str):
 
 
 def to_np_array(apng_img: apng.APNG) -> np.ndarray:
-
     frames_arr = []
 
     for frame, control in apng_img.frames:
@@ -102,7 +111,6 @@ def to_np_array(apng_img: apng.APNG) -> np.ndarray:
 
 
 def im_write_multi_apng(file_name: str, img_array: np.ndarray) -> Tuple[bool, np.ndarray]:
-
     sub_frames_fn_list = []
 
     for i in range(img_array.shape[0]):
@@ -134,7 +142,7 @@ def write_multi_frame(out_img_path: str, img_array: np.ndarray, is_single_channe
     """
 
     # Pre-condition(s)
-    assert is_single_channel and len(img_array.shape) == 3 or\
+    assert is_single_channel and len(img_array.shape) == 3 or \
            not is_single_channel and len(img_array.shape) == 4, "Image is single frame!"
 
     out_img_path_tiff, out_img_path_apng = [out_img_path.replace(".png", format_) for format_ in (".tiff", ".apng")]
@@ -148,7 +156,7 @@ def write_multi_frame(out_img_path: str, img_array: np.ndarray, is_single_channe
     assert status_ is True, "Error writing apng image"
 
     assert (saved_img_array_tiff == saved_img_array_apng).all(), "Quality loss in either apng " \
-                                                                         "or tiff multi-frame image files."
+                                                                 "or tiff multi-frame image files."
 
     return saved_img_array_tiff
 

--- a/parameters.py
+++ b/parameters.py
@@ -20,6 +20,14 @@ CAVIF_RS_SUPPORTED_VERSIONS: tuple = ("1.3.4",)
 AVIF_DECODE_SUPPORTED_VERSIONS: tuple = ("0.2.2",)
 WEBP_SUPPORTED_VERSIONS: tuple = ("0.4.1",)
 
+# FILENAME_KEYWORDS = id
+MODALITY = 0
+BODYPART = 1
+COLORSPACE = 2
+SAMPLES_PER_PIXEL = 3
+BITS_PER_SAMPLE = 4
+DEPTH = 5  # Number of frames in the image (> 1 if multi frame)
+
 # Default settings per compression method
 DEFAULTS = dict(
     jxl=dict(quality=1., effort=7),

--- a/parameters.py
+++ b/parameters.py
@@ -12,6 +12,7 @@ LOSSLESS_EXTENSION: str = ".png"
 PROCEDURE_RESULTS_FILE: str = "procedure_results"
 JPEG_EVAL_RESULTS_FILE: str = "jpeg_eval_results"
 DATASET_PATH: str = "images/dataset/"
+DATASET_COMPRESSED_PATH: str = "images/dataset_compressed/"
 
 # Info flags
 JXL_SUPPORTED_VERSIONS: tuple = ("0.6.1",)

--- a/procedure.py
+++ b/procedure.py
@@ -3,14 +3,15 @@ import os.path
 import re
 import time
 from subprocess import Popen, PIPE
-from typing import List, Dict, Tuple, Union
+from typing import List, Dict, Tuple
 
 import cv2
 import numpy as np
 import pandas as pd
 
 import metrics
-from parameters import LOSSLESS_EXTENSION, PROCEDURE_RESULTS_FILE, DATASET_PATH
+import util
+from parameters import LOSSLESS_EXTENSION, PROCEDURE_RESULTS_FILE, DATASET_PATH, DATASET_COMPRESSED_PATH
 
 """
     Codecs' versions
@@ -18,7 +19,6 @@ from parameters import LOSSLESS_EXTENSION, PROCEDURE_RESULTS_FILE, DATASET_PATH
         cwebp, dwebp -> v0.4.1
         cavif -> v1.3.4
         avif_decode -> 0.2.2
-            (not sure, can't check w/ -V, I ran cargo install at 4 Apr 2022)
 """
 
 
@@ -43,11 +43,11 @@ def check_codecs():
 def encode_jxl(target_image: str, distance: float, effort: int, output_path: str) -> float:
     """ Encodes an image using the cjxl program
 
-    :param target_image: Path to image targeted for compression encoding
-    :param distance: Quality setting as set by cjxl (butteraugli --distance)
-    :param effort: --effort level parameter as set by cjxl
-    :param output_path: Path where the dataset_compressed image should go to
-    :return: Compression speed, in MP/s
+    @param target_image: Path to image targeted for compression encoding
+    @param distance: Quality setting as set by cjxl (butteraugli --distance)
+    @param effort: --effort level parameter as set by cjxl
+    @param output_path: Path where the dataset_compressed image should go to
+    @return: Compression speed, in MP/s
     """
     pixels = total_pixels(target_image)
 
@@ -64,11 +64,11 @@ def encode_jxl(target_image: str, distance: float, effort: int, output_path: str
 def encode_avif(target_image: str, quality: int, speed: int, output_path: str) -> float:
     """ Encodes an image using the cavif(-rs) program
 
-    :param target_image: Input/Original image
-    :param quality: --quality configuration
-    :param speed: --speed configuration
-    :param output_path: Directory where the dataset_compressed file
-    :return: Compression speed, in MP/s
+    @param target_image: Input/Original image
+    @param quality: --quality configuration
+    @param speed: --speed configuration
+    @param output_path: Directory where the dataset_compressed file
+    @return: Compression speed, in MP/s
     """
 
     pixels = total_pixels(target_image)
@@ -89,11 +89,11 @@ def encode_avif(target_image: str, quality: int, speed: int, output_path: str) -
 def encode_webp(target_image: str, quality: int, effort: int, output_path: str) -> float:
     """ Encodes an image using the cwebp program
 
-    :param target_image: path/to/image.ext, where the extension needs to be supported by cwebp
-    :param quality: Quality loss level (1 to 100), -q option of the tool
-    :param effort: Effort of the encoding process (-m option of the tool)
-    :param output_path: Directory where the compression
-    :return: Compression speed, in MP/s
+    @param target_image: path/to/image.ext, where the extension needs to be supported by cwebp
+    @param quality: Quality loss level (1 to 100), -q option of the tool
+    @param effort: Effort of the encoding process (-m option of the tool)
+    @param output_path: Directory where the compression
+    @return: Compression speed, in MP/s
     """
 
     # Command to be executed for the compression
@@ -112,13 +112,13 @@ def timed_command(stdin: str) -> float:
 
     Note: Execution timeout implemented to 60 seconds
 
-    :param stdin: Used to run the subshell command
-    :return: Time it took for the command to run (in seconds)
+    @param stdin: Used to run the subshell command
+    @return: Time it took for the command to run (in seconds)
     """
     # Execute command and time the CT
     start = time.time()
     p = Popen(stdin, shell=True, stdout=PIPE, stderr=PIPE)
-    _, stderr = p.communicate(timeout=60)
+    _, stderr = p.communicate(timeout=120)
     ct = time.time() - start  # or extract_webp_ct(stderr)
     # Check for errors
     return_code: int = p.returncode
@@ -132,18 +132,24 @@ def timed_command(stdin: str) -> float:
 
 
 def total_pixels(target_image: str) -> int:
-    """ Counts the number of pixels on an image
+    """Counts the number of pixels on an image
 
     Count method: height * height
 
-    :param target_image: Input image path
-    :return: Number of pixels
+    @param target_image: Input image path
+    @return: Number of pixels
     """
 
     # Parameter checking
     assert os.path.exists(target_image), f"Image at \"{target_image}\" does not exist!"
 
     # Extract resolution
+    if target_image.endswith("apng"):
+        height, width = util.get_apng_frames_resolution(target_image)
+        depth = util.get_apng_depth(target_image)
+
+        return height * width * depth
+
     height, width = cv2.imread(target_image).shape[:2]
     # Number of pixels in the image
     pixels = height * width
@@ -153,8 +159,8 @@ def total_pixels(target_image: str) -> int:
 def extract_jxl_ds(stderr: bytes) -> float:
     """ Extract decompression speed from the djxl output
 
-    :param stderr: Console output
-    :return: Decompression speed, in MP/s
+    @param stderr: Console output
+    @return: Decompression speed, in MP/s
     """
 
     ds: str = re.findall(r"\d+.\d+ MP/s", str(stderr, "utf-8"))[0]
@@ -165,11 +171,11 @@ def extract_jxl_ds(stderr: bytes) -> float:
 def extract_webp_dt(stderr: bytes) -> float:
     """ Extract decompression speed from the dwebp output
 
-    :param stderr: Console output
-    :return: Decompression speed, in MP/s
+    @param stderr: Console output
+    @return: Decompression speed, in MP/s
     """
     # Extract
-    ds: str = re.findall(r"Time to decode picture: \d+.\d+s", str(stderr, "utf-8"))[0]\
+    ds: str = re.findall(r"Time to decode picture: \d+.\d+s", str(stderr, "utf-8"))[0] \
         .split("Time to decode picture: ")[-1]
     return float(ds[:-1])
 
@@ -177,9 +183,9 @@ def extract_webp_dt(stderr: bytes) -> float:
 def extract_resolution(stderr: bytes, sep: str = "x") -> List[str]:
     """ Extract resolution from dwebp or djxl
 
-    :param stderr: Console output
-    :param sep: Separator string - e.g.: 1920x1080, sep="x"
-    :return:
+    @param stderr: Console output
+    @param sep: Separator string - e.g.: 1920x1080, sep="x"
+    @return:
     """
 
     res: str = re.findall(rf"\d+{sep}\d+", str(stderr))[0]
@@ -189,60 +195,71 @@ def extract_resolution(stderr: bytes, sep: str = "x") -> List[str]:
 def decode_compare(target_image: str) -> Tuple[float, float, float, float, float]:
     """ Decodes the image and returns the process' metadata
 
-    :param target_image: Path to the image to be decoded
-    :return: CR, DT(MP/s), MSE, PSNR, SSIM regarding the compression applied to the image
+    @param target_image: Path to the image to be decoded
+    @return: CR, DT(MP/s), MSE, PSNR, SSIM regarding the compression applied to the image
     """
 
     # Get original image
     og_image_path = get_og_image(compressed=target_image, only_path=True)
 
+    encoded_extension: str = target_image.split(".")[-1]
+    decoded_extension = og_image_path.split(".")[-1]
+
     pixels = total_pixels(og_image_path)
 
     cr: float = os.path.getsize(og_image_path) / os.path.getsize(target_image)
 
-    extension: str = target_image.split(".")[-1]
+    match encoded_extension:
+        case "jxl":
 
-    # Same directory, same name, .png
-    out_path: str = ".".join(target_image.split(".")[:-1]) + LOSSLESS_EXTENSION
+            decoded_path: str = target_image.replace("jxl", decoded_extension)
 
-    if extension == "jxl":
-        # Construct decoding command
-        command: str = f"djxl {target_image} {out_path}"
+            # Construct decoding command
+            command: str = f"djxl {target_image} {decoded_path}"
 
-        dt = timed_command(command)
+            dt = timed_command(command)
 
-        # Compute decoding speed (MP/s)
-        ds = pixels / (dt * 1e6)
-    elif extension == "avif":
-        # Construct decoding command
-        command: str = f"avif_decode {target_image} {out_path}"
+            # Compute decoding speed (MP/s)
+            ds = pixels / (dt * 1e6)
+        case "avif":
 
-        dt = timed_command(command)
+            # Same directory, same name, .png
+            decoded_path: str = target_image.replace("avif", decoded_extension)
 
-        # Compute decoding speed (MP/s)
-        ds = pixels / (dt * 1e6)
-    elif extension == "webp":
-        # Construct decoding command
-        command: str = f"dwebp -v {target_image} -o {out_path}"
+            # Construct decoding command
+            command: str = f"avif_decode {target_image} {decoded_path}"
 
-        dt = timed_command(command)
+            dt = timed_command(command)
 
-        # Compute decoding speed (MP/s)
-        ds = pixels / (dt * 1e6)
+            # Compute decoding speed (MP/s)
+            ds = pixels / (dt * 1e6)
+        case "webp":
+
+            decoded_path: str = target_image.replace("webp", decoded_extension)
+
+            # Construct decoding command
+            additional_options = "-tiff" if decoded_path.endswith("tiff") else ""
+            command: str = f"dwebp -v {target_image} {additional_options} -o {decoded_path}"
+
+            dt = timed_command(command)
+
+            # Compute decoding speed (MP/s)
+            ds = pixels / (dt * 1e6)
+        case _:
+            raise AssertionError(f"Unsupported extension for decoding: {encoded_extension}")
+
+    # Read the output images w/ opencv
+    if decoded_path.endswith("apng"):
+        decoded_image = util.read_apng(decoded_path)
+        og_image = util.read_apng(og_image_path)
     else:
-        raise AssertionError(f"Unsupported extension for decoding: {extension}")
-
-    # Read the output image w/ opencv
-    out_image = cv2.imread(out_path, cv2.IMREAD_GRAYSCALE)
-    og_image = cv2.imread(og_image_path, cv2.IMREAD_UNCHANGED)
+        decoded_image = cv2.imread(decoded_path, cv2.IMREAD_UNCHANGED)
+        og_image = cv2.imread(og_image_path, cv2.IMREAD_UNCHANGED)
 
     # Evaluate the quality of the resulting image
-    mse: float = metrics.mse(og_image, out_image)
-    psnr: float = metrics.psnr(og_image, out_image)
-    ssim: float = metrics.ssim(og_image, out_image.astype(np.uint16))
-
-    if mse == 0:
-        raise AssertionError("Images are equal")
+    mse: float = metrics.mse(og_image, decoded_image)
+    psnr: float = metrics.psnr(og_image, decoded_image)
+    ssim: float = metrics.custom_ssim(og_image, decoded_image.astype(np.uint16))
 
     return cr, ds, mse, psnr, ssim
 
@@ -250,8 +267,8 @@ def decode_compare(target_image: str) -> Tuple[float, float, float, float, float
 def extract_jxl_cs(stderr: bytes) -> str:
     """ Extracts compression speed from a cjxl output
 
-    :param stderr: Console output
-    :return: Compression speed, in MP/s
+    @param stderr: Console output
+    @return: Compression speed, in MP/s
     """
 
     # Find decoding speed in the output pool
@@ -262,8 +279,8 @@ def extract_jxl_cs(stderr: bytes) -> str:
 def extract_webp_ct(stderr: bytes) -> float:
     """ Extracts compression speed from a cjxl output
 
-    :param stderr: Console output
-    :return: Compression speed, in MP/s
+    @param stderr: Console output
+    @return: Compression speed, in MP/s
     """
 
     # Extract DT from output
@@ -274,16 +291,25 @@ def extract_webp_ct(stderr: bytes) -> float:
     return dt
 
 
-def get_og_image(compressed, only_path: bool = False) -> Union[np.ndarray, str]:
+def get_og_image(compressed, only_path: bool = False) -> np.ndarray | str:
     """ Extract info on the original image given the compressed one
 
-    :param compressed: Path to compressed image
-    :param only_path: Optional flag - Set to true to return only the path to the og image
-    :return: Original image's path or contents
+    Note: if returned .multi, means that it is a multi-frame image.
+        This means there are multiple og images - their extensions are stored in parameters.MULTI_FRAME_EXT...
+
+    @param compressed: Path to compressed image
+    @param only_path: Optional flag - Set to true to return only the path to the og image
+    @return: Original image's path or contents
     """
+
     # Get original lossless image
     og_image_path = "".join(compressed.split("_compressed"))
-    og_image_path = "_".join(og_image_path.split("_")[:-1]) + LOSSLESS_EXTENSION
+
+    og_number_frames = int(og_image_path.split(".")[0].split("_")[5])
+
+    og_image_path = "_".join(og_image_path.split("_")[:-1])
+    if og_number_frames == 1:
+        og_image_path += LOSSLESS_EXTENSION
 
     if only_path is True:
         return og_image_path
@@ -294,9 +320,9 @@ def get_og_image(compressed, only_path: bool = False) -> Union[np.ndarray, str]:
 def image_to_dir(dataset_path: str, target_image: str) -> str:
     """ Not used anymore
 
-    :param dataset_path: Path to the dataset folder (dataset for compressed is a sibling folder)
-    :param target_image: Path to the image from the original dataset
-    :return: Path to the folder in the dataset_compressed where the compressed form of
+    @param dataset_path: Path to the dataset folder (dataset for compressed is a sibling folder)
+    @param target_image: Path to the image from the original dataset
+    @return: Path to the folder in the dataset_compressed where the compressed form of
         target_image should be stored
     """
     # Do a "cd ../dataset_compressed"
@@ -324,9 +350,9 @@ def bulk_compress(jxl: bool = True, avif: bool = True, webp: bool = True):
     for that instance - MODALITY_BODY-PART_NUM-TAG_q{float}_e{int}.FORMAT e.g.: CT_HEAD_12_q3.0_e7.jxl
 
 
-    :param webp: If true, toggle WEBP eval (default=True)
-    :param avif: If true, toggle AVIF eval (default=True)
-    :param jxl: If true, toggle JPEG XL eval (default=True)
+    @param webp: If true, toggle WEBP eval (default=True)
+    @param avif: If true, toggle AVIF eval (default=True)
+    @param jxl: If true, toggle JPEG XL eval (default=True)
     """
 
     if all(codec is False for codec in (jxl, avif, webp)):
@@ -357,9 +383,12 @@ def bulk_compress(jxl: bool = True, avif: bool = True, webp: bool = True):
     # JPEG XL evaluation
     if jxl is True:
         for target_image in image_list:
+
+            if not target_image.endswith("apng") and not target_image.endswith("png"):
+                continue
+
             for quality in quality_param_jxl:
                 for effort in effort_jxl:
-
                     # Set output path of compressed
                     outfile_name, output_path = get_output_path(
                         dataset_path=DATASET_PATH, effort=effort,
@@ -367,7 +396,7 @@ def bulk_compress(jxl: bool = True, avif: bool = True, webp: bool = True):
                     )
 
                     # Print image analysis
-                    print(f"Started analysing image \"{outfile_name}\"...", end="")
+                    print(f"Started analysing image \"{outfile_name}\"", end="...")
 
                     # Add wildcard for now because the extensions are missing
                     cs = encode_jxl(target_image=DATASET_PATH + target_image,
@@ -383,6 +412,10 @@ def bulk_compress(jxl: bool = True, avif: bool = True, webp: bool = True):
     # AVIF
     if avif is True:
         for target_image in image_list:
+
+            if not target_image.endswith("png"):
+                continue
+
             for quality in quality_param_avif:
                 for speed in speed_avif:
                     # Construct output file total path
@@ -407,6 +440,10 @@ def bulk_compress(jxl: bool = True, avif: bool = True, webp: bool = True):
     # WebP
     if webp is True:
         for target_image in image_list:
+
+            if not target_image.endswith("png") and not target_image.endswith("tiff"):
+                continue
+
             for quality in quality_param_webp:
                 for effort in effort_webp:
                     # Construct output file total path
@@ -436,12 +473,12 @@ def bulk_compress(jxl: bool = True, avif: bool = True, webp: bool = True):
 
 
 def original_basename(intended_abs_filepath: str) -> str:
-    """ Get an original filename given the absolute path
+    """Get an original filename given the absolute path
 
     Example - give path/to/filename.txt -> it already exists -> return path/to/filename_1.txt
 
-    :param intended_abs_filepath: Absolute path to a file not yet written (w/o the file's extension)
-    :return: Same path, with basename of the file changed to an original one
+    @param intended_abs_filepath: Absolute path to a file not yet written (w/o the file's extension)
+    @return: Same path, with basename of the file changed to an original one
     """
     # Separate path from extension
     extension: str = intended_abs_filepath.split(".")[-1]
@@ -458,20 +495,20 @@ def original_basename(intended_abs_filepath: str) -> str:
 
 
 def finalize(cs: float, outfile_name: str, output_path: str, stats: pd.DataFrame) -> pd.DataFrame:
-    """ Decode, collect eval data and remove compressed image.
+    """Decode, collect eval data and remove compressed image.
 
     Decodes the target image file, deletes it and saves metadata to the provided dataframe
 
-    :param cs: Compression time of the provided compressed image file
-    :param outfile_name: Basename of the provided file (compressed image)
-    :param output_path: Path to the provided file (compressed image)
-    :param stats: Dataframe holding the data regarding the compressions
-    :return: Updated Dataframe
+    @param cs: Compression time of the provided compressed image file
+    @param outfile_name: Basename of the provided file (compressed image)
+    @param output_path: Path to the provided file (compressed image)
+    @param stats: Dataframe holding the data regarding the compressions
+    @return: Updated Dataframe
     """
     cr, ds, mse, psnr, ssim = decode_compare(output_path)
     # Remove generated (png and jxl) images
-    os.remove(output_path)
-    os.remove(".".join(output_path.split(".")[:-1]) + LOSSLESS_EXTENSION)
+    for file in os.listdir(DATASET_COMPRESSED_PATH):
+        os.remove(os.path.abspath(DATASET_COMPRESSED_PATH+file))
     # Append new stats do dataframe
     row = pd.DataFrame(
         dict(filename=[outfile_name], cs=[cs], ds=[ds], cr=[cr], mse=[mse], psnr=[psnr], ssim=[ssim])
@@ -483,17 +520,16 @@ def finalize(cs: float, outfile_name: str, output_path: str, stats: pd.DataFrame
 def get_output_path(dataset_path: str, target_image: str, effort: int, quality: float, format_: str) -> Tuple[str, str]:
     """ Compute the output path of the compressed version of the target image.
 
-    :param dataset_path: Dataset containing the target image.
-    :param target_image: Input, original and lossless image.
-    :param effort: Effort/speed configuration with which the image compression process will be set to.
-    :param quality: Quality configuration with which the image compression process will be set to.
-    :param format_: Image compression algorithm's extension, e.g.: jxl
-    :return: Output file basename and path
+    @param dataset_path: Dataset containing the target image.
+    @param target_image: Input, original and lossless image.
+    @param effort: Effort/speed configuration with which the image compression process will be set to.
+    @param quality: Quality configuration with which the image compression process will be set to.
+    @param format_: Image compression algorithm's extension, e.g.: jxl
+    @return: Output file basename and path
     """
 
     # Construct output file total path
-    outfile_name: str = target_image.split(LOSSLESS_EXTENSION)[0] \
-                        + "_" + f"q{quality}-e{effort}.{format_}"
+    outfile_name: str = target_image.split(LOSSLESS_EXTENSION)[0] + "_" + f"q{quality}-e{effort}.{format_}"
     # Trim trailing slash "/"
     trimmed: list = dataset_path.split("/")
     trimmed.remove("")
@@ -553,12 +589,8 @@ def squeeze_data():
 
 
 if __name__ == '__main__':
-    # Workaround to a local issue
-    #   For some reason, the subshell doesn't recognize the cwebp tool
-    os.environ["PATH"] = f"{os.path.expanduser('~')}" \
-                         f"/libwebp-0.4.1-linux-x86-64/bin:" + os.environ["PATH"]
 
     check_codecs()
 
-    bulk_compress(jxl=True, avif=True, webp=True)
+    bulk_compress(jxl=False, avif=True, webp=True)
     squeeze_data()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,11 @@
 matplotlib~=3.5.2
 numpy~=1.22.1
-pandas~=1.2.4
+pandas~=1.4.3
 pydicom==2.3.0
 opencv-python~=4.5.5.64
-scikit-image~=0.18.1
+scikit-image~=0.19.3
 Pillow~=9.0.1
 apng~=0.3.4
+gdcm~=1.1
+pylibjpeg~=1.4.0
+pylibjpeg-libjpeg~=1.3.1

--- a/util.py
+++ b/util.py
@@ -1,0 +1,70 @@
+"""Miscellaneous utility functions
+
+"""
+
+import os
+
+import cv2
+import numpy as np
+from apng import APNG, PNG
+from numpy import ndarray
+
+
+def get_apng_frames_resolution(filename: str) -> tuple[int, int]:
+    """
+
+    @param filename: APNG image file name
+    @return: height, width
+    """
+
+    apng_img = APNG.open(filename)
+
+    first_frame, _ = apng_img.frames[0]
+
+    tmp: ndarray = read_apng_frame(first_frame)
+
+    return tmp.shape[:2]
+
+
+def read_apng_frame(frame: PNG) -> ndarray:
+    """
+
+    @param frame: Single frame from an APNG
+    @return:
+    """
+    tmp_fname = "tmp.png"
+    frame.save(tmp_fname)
+    tmp = cv2.imread(tmp_fname, cv2.IMREAD_UNCHANGED)
+    os.remove(tmp_fname)
+    return tmp
+
+
+def to_np_array(apng_img: APNG) -> ndarray:
+    """
+
+    @param apng_img: APNG image parsed object
+    @return: Numpy ndarray with the images contents
+    """
+    frames_arr: list[ndarray] = [read_apng_frame(frame) for frame, _ in apng_img.frames]
+
+    return np.array(frames_arr)
+
+
+def read_apng(filename: str) -> ndarray:
+    """
+
+    @param filename: .apng image file name - E.g.: "image.png"
+    @return: Numpy ndarray with the images contents
+    """
+    return to_np_array(
+        APNG.open(filename)
+    )
+
+
+def get_apng_depth(target_image: str) -> int:
+    """
+
+    @param target_image: Image to be evaluated
+    @return: Number of frames in the multi-frame image
+    """
+    return len(APNG.open(target_image).frames)


### PR DESCRIPTION
Multi-frame images only supported from the `cjxl` encoder.
`dicom-parser.py` and `procedure.py` modules are functional

`visualize.py` for a future development iteration.