### PR TITLE
Custom multiframe support for avif and webp

### DIFF
--- a/custom_apng.py
+++ b/custom_apng.py
@@ -1,0 +1,108 @@
+"""APNG procedures - read/write to/from numpy ndarray
+
+"""
+import os
+
+import apng
+import cv2
+import numpy as np
+from apng import APNG, PNG
+from numpy import ndarray
+
+
+def get_apng_frames_resolution(filename: str) -> tuple[int, int]:
+    """
+
+    @param filename: APNG image file name
+    @return: height, width
+    """
+
+    apng_img = APNG.open(filename)
+
+    first_frame, _ = apng_img.frames[0]
+
+    tmp: ndarray = read_apng_frame(first_frame)
+
+    return tmp.shape[:2]
+
+
+def read_apng_frame(frame: PNG) -> ndarray:
+    """
+
+    @param frame: Single frame from an APNG
+    @return:
+    """
+    tmp_fname = "tmp.png"
+    frame.save(tmp_fname)
+    tmp = cv2.imread(tmp_fname, cv2.IMREAD_UNCHANGED)
+    os.remove(tmp_fname)
+    return tmp
+
+
+def to_np_array(apng_img: APNG) -> ndarray:
+    """
+
+    @param apng_img: APNG image parsed object
+    @return: Numpy ndarray with the images contents
+    """
+    frames_arr: list[ndarray] = [read_apng_frame(frame) for frame, _ in apng_img.frames]
+
+    return np.array(frames_arr)
+
+
+def read_apng(filename: str) -> ndarray:
+    """
+
+    @param filename: .apng image file name - E.g.: "image.png"
+    @return: Numpy ndarray with the images contents
+    """
+    return to_np_array(
+        APNG.open(filename)
+    )
+
+
+def get_apng_depth(target_image: str) -> int:
+    """
+
+    @param target_image: Image to be evaluated
+    @return: Number of frames in the multi-frame image
+    """
+    return len(APNG.open(target_image).frames)
+
+
+def staple_pngs(output_path, *pngs: str) -> bool:
+    """Joins multiple png images into animated png format
+
+    @param output_path: apng output file name
+    @param pngs: png file names list
+    @return: Status code
+    """
+    frames = np.array(cv2.imread(img) for img in pngs)
+
+    return write_apng(output_path, frames)[0]
+
+
+def write_apng(file_name: str, img_array: np.ndarray) -> tuple[bool, np.ndarray]:
+    """Writes the contents of a ndarray to an apng file
+
+    @param file_name: file name of the apng file
+    @param img_array: Contents to be written to apng format
+    @return: Status code, ndarray with the apng contents (used to check if no change has occurred)
+    """
+    sub_frames_fn_list = []
+
+    for i in range(img_array.shape[0]):
+        frame: np.ndarray = img_array[i]
+
+        sub_frame_fname = f"tmp{i}.png"
+        sub_frames_fn_list.append(sub_frame_fname)
+
+        cv2.imwrite(sub_frame_fname, frame, params=[cv2.IMWRITE_TIFF_COMPRESSION, 1])
+
+    apng_img = apng.APNG.from_files(sub_frames_fn_list)
+    apng_img.save(file_name)
+
+    for i in range(img_array.shape[0]):
+        os.remove(f"tmp{i}.png")
+
+    return True, to_np_array(apng_img)

--- a/custom_apng.py
+++ b/custom_apng.py
@@ -77,7 +77,7 @@ def staple_pngs(output_path, *pngs: str) -> bool:
     @param pngs: png file names list
     @return: Status code
     """
-    frames = np.array(cv2.imread(img) for img in pngs)
+    frames = np.array([cv2.imread(img, cv2.IMREAD_UNCHANGED) for img in pngs])
 
     return write_apng(output_path, frames)[0]
 

--- a/procedure.py
+++ b/procedure.py
@@ -202,15 +202,16 @@ def decode_compare(encoded_path: str, og_image_path) -> tuple[float, float, floa
             decoded_path: str = encoded_path.replace("avif", decoded_extension)
 
             if og_image_path.endswith(".apng"):
+                # Execute decode command for all frames and collect DTs
                 dt = custom_multiframe_decoding(decoded_path, encoded_extension)
+
             elif og_image_path.endswith(".png"):
                 # Construct decoding command
                 command = construct_davif(decoded_path, encoded_path)
 
                 dt = timed_command(command)
 
-                og_channels = dataset_img_info(encoded_path, SAMPLES_PER_PIXEL)
-                if og_channels == "1" and not og_image_path.endswith(".apng"):
+                if dataset_img_info(encoded_path, SAMPLES_PER_PIXEL) == "1":
                     # AVIF output is always RGB/YCbCr
                     transcode_gray(decoded_path)
             else:
@@ -227,16 +228,17 @@ def decode_compare(encoded_path: str, og_image_path) -> tuple[float, float, floa
                 # Execute decode command for all frames and collect DTs
                 dt = custom_multiframe_decoding(decoded_path, encoded_extension)
 
-            elif encoded_path.endswith(".png"):
+            elif og_image_path.endswith(".png"):
                 # Construct decoding command
                 command = construct_dwebp(decoded_path, encoded_path)
 
                 dt = timed_command(command)
 
                 if dataset_img_info(encoded_path, SAMPLES_PER_PIXEL) == "1":
+                    # WebP output is always RGB/YCbCr
                     transcode_gray(decoded_path)
             else:
-                raise AssertionError(f"Illegal input image format: '{encoded_path}'")
+                raise AssertionError(f"Illegal input image format: '{og_image_path}'")
 
             # Compute decoding speed (MP/s)
             ds = pixels / (dt * 1e6)

--- a/procedure.py
+++ b/procedure.py
@@ -7,19 +7,19 @@
 
 import json
 import os.path
-import re
-import time
-from subprocess import Popen, PIPE
-from typing import List, Dict, Tuple
+from functools import partial
+from typing import Callable
 
 import cv2
 import numpy as np
 import pandas as pd
 
+import custom_apng
 import metrics
-import util
-from parameters import LOSSLESS_EXTENSION, PROCEDURE_RESULTS_FILE, DATASET_PATH, DATASET_COMPRESSED_PATH, \
-    SAMPLES_PER_PIXEL
+from parameters import LOSSLESS_EXTENSION, PROCEDURE_RESULTS_FILE, DATASET_PATH, SAMPLES_PER_PIXEL, \
+    DATASET_COMPRESSED_PATH
+from util import construct_djxl, construct_davif, construct_dwebp, construct_cwebp, construct_cavif, construct_cjxl, \
+    timed_command, total_pixels, original_basename, rm_encoded
 
 """
     Codecs' versions
@@ -49,7 +49,7 @@ def check_codecs():
 
 
 def encode_jxl(target_image: str, distance: float, effort: int, output_path: str) -> float:
-    """ Encodes an image using the cjxl program
+    """Encodes an image using the cjxl program
 
     @param target_image: Path to image targeted for compression encoding
     @param distance: Quality setting as set by cjxl (butteraugli --distance)
@@ -60,8 +60,7 @@ def encode_jxl(target_image: str, distance: float, effort: int, output_path: str
     pixels = total_pixels(target_image)
 
     # Construct the encoding command
-    command: str = f"cjxl {target_image} {output_path} " \
-                   f"--distance={distance} --effort={effort} --quiet"
+    command = construct_cjxl(distance, effort, output_path, target_image)
 
     # Run and extract ct
     ct = timed_command(command)
@@ -70,21 +69,25 @@ def encode_jxl(target_image: str, distance: float, effort: int, output_path: str
 
 
 def encode_avif(target_image: str, quality: int, speed: int, output_path: str) -> float:
-    """ Encodes an image using the cavif(-rs) program
+    """Encodes an image using the cavif(-rs) program
 
     @param target_image: Input/Original image
     @param quality: --quality configuration
     @param speed: --speed configuration
-    @param output_path: Directory where the dataset_compressed file
+    @param output_path: Encoded file output path
     @return: Compression speed, in MP/s
     """
+
+    if target_image.endswith(".apng"):
+        encode_part = partial(encode_avif, quality=quality, speed=speed)
+        format_ = "avif"
+
+        return custom_multiframe_encoding(encode_part, format_, output_path, target_image)
 
     pixels = total_pixels(target_image)
 
     # Construct the command
-    command: str = f"cavif -o {output_path} " \
-                   f"--quality {quality} --speed {speed} --quiet " \
-                   f"{os.path.abspath(target_image)}"
+    command = construct_cavif(output_path, quality, speed, target_image)
 
     ct = timed_command(command)
 
@@ -95,7 +98,7 @@ def encode_avif(target_image: str, quality: int, speed: int, output_path: str) -
 
 
 def encode_webp(target_image: str, quality: int, effort: int, output_path: str) -> float:
-    """ Encodes an image using the cwebp program
+    """Encodes an image using the cwebp program
 
     @param target_image: path/to/image.ext, where the extension needs to be supported by cwebp
     @param quality: Quality loss level (1 to 100), -q option of the tool
@@ -104,8 +107,14 @@ def encode_webp(target_image: str, quality: int, effort: int, output_path: str) 
     @return: Compression speed, in MP/s
     """
 
+    if target_image.endswith(".apng"):
+        format_ = "webp"
+        encode_part = partial(encode_webp, quality=quality, effort=effort)
+
+        return custom_multiframe_encoding(encode_part, format_, output_path, target_image)
+
     # Command to be executed for the compression
-    command: str = f"cwebp -quiet -v -q {quality} -m {effort} {target_image} -o {output_path}"
+    command = construct_cwebp(effort, output_path, quality, target_image)
 
     ct = timed_command(command)
 
@@ -115,115 +124,73 @@ def encode_webp(target_image: str, quality: int, effort: int, output_path: str) 
     return pixels / (ct * 1e6)
 
 
-def timed_command(stdin: str) -> float:
-    """ Runs a given command on a subshell and records its execution time
+def custom_multiframe_encoding(encode_part, format_, output_path, input_image) -> float:
+    """Encodes a multi-frame apng image file into multiple frames
 
-    Note: Execution timeout implemented to 60 seconds
+    This is for formats which don't support multiple frame images w/ >8 bits per sample
 
-    @param stdin: Used to run the subshell command
-    @return: Time it took for the command to run (in seconds)
-    """
-    # Execute command and time the CT
-    start = time.time()
-    p = Popen(stdin, shell=True, stdout=PIPE, stderr=PIPE)
-    _, stderr = p.communicate(timeout=120)
-    ct = time.time() - start  # or extract_webp_ct(stderr)
-    # Check for errors
-    return_code: int = p.returncode
-    if return_code != 0:
-        print(f"Error code {return_code}, executing:"
-              f"\nStdIn -> {stdin}"
-              f"\nStdErr -> {stderr}")
-        exit(1)
-
-    return ct
-
-
-def total_pixels(target_image: str) -> int:
-    """Counts the number of pixels on an image
-
-    Count method: height * height
-
-    @param target_image: Input image path
-    @return: Number of pixels
-    """
-
-    # Parameter checking
-    assert os.path.exists(target_image), f"Image at \"{target_image}\" does not exist!"
-
-    # Extract resolution
-    if target_image.endswith("apng"):
-        height, width = util.get_apng_frames_resolution(target_image)
-        depth = util.get_apng_depth(target_image)
-
-        return height * width * depth
-
-    height, width = cv2.imread(target_image).shape[:2]
-    # Number of pixels in the image
-    pixels = height * width
-    return pixels
-
-
-def extract_jxl_ds(stderr: bytes) -> float:
-    """ Extract decompression speed from the djxl output
-
-    @param stderr: Console output
-    @return: Decompression speed, in MP/s
-    """
-
-    ds: str = re.findall(r"\d+.\d+ MP/s", str(stderr, "utf-8"))[0]
-
-    return float(ds[:-5])
-
-
-def extract_webp_dt(stderr: bytes) -> float:
-    """ Extract decompression speed from the dwebp output
-
-    @param stderr: Console output
-    @return: Decompression speed, in MP/s
-    """
-    # Extract
-    ds: str = re.findall(r"Time to decode picture: \d+.\d+s", str(stderr, "utf-8"))[0] \
-        .split("Time to decode picture: ")[-1]
-    return float(ds[:-1])
-
-
-def extract_resolution(stderr: bytes, sep: str = "x") -> List[str]:
-    """ Extract resolution from dwebp or djxl
-
-    @param stderr: Console output
-    @param sep: Separator string - e.g.: 1920x1080, sep="x"
+    @param encode_part:
+    @param format_:
+    @param output_path:
+    @param input_image:
     @return:
     """
+    print("Custom encoding multi-frame image.")
 
-    res: str = re.findall(rf"\d+{sep}\d+", str(stderr))[0]
-    return res.split(sep)
+    multiframe_img = custom_apng.read_apng(input_image)
+    cs_list: list[float] = []
+    for i, frame in enumerate(multiframe_img):
+        # Write the multiple frames as .png in DATASET_COMPRESSED_PATH
+        frame_name = output_path.replace(f".{format_}", f"-{i}.png")
+        cv2.imwrite(frame_name, frame)
+        # Recursively call this function for every written png frame (and save cs for each one)
+        cs_list.append(
+            encode_part(
+                target_image=frame_name,
+                output_path=output_path.replace(f".{format_}", f"-{i}.{format_}")
+            )
+        )
+        print(f"Encoded frame {i}")
+        # Delete lossless frame
+        os.remove(frame_name)
+    # Compute the appropriate cs and return it
+    return np.array(cs_list).mean()
 
 
-def decode_compare(target_image: str) -> Tuple[float, float, float, float, float]:
+def decode_compare(encoded_path: str, og_image_path) -> tuple[float, float, float, float, float]:
     """ Decodes the image and returns the process' metadata
 
-    @param target_image: Path to the image to be decoded
-    @return: CR, DT(MP/s), MSE, PSNR, SSIM regarding the compression applied to the image
+    @param og_image_path:
+    @param encoded_path: Path to the image to be decoded
+    @return: CR, DS(MP/s), MSE, PSNR, SSIM regarding the compression applied to the image
     """
 
-    # Get original image
-    og_image_path = get_og_image(compressed=target_image, only_path=True)
-
-    encoded_extension: str = target_image.split(".")[-1]
+    encoded_extension: str = encoded_path.split(".")[-1]
     decoded_extension = og_image_path.split(".")[-1]
 
     pixels = total_pixels(og_image_path)
 
-    cr: float = os.path.getsize(og_image_path) / os.path.getsize(target_image)
+    if encoded_extension == "jxl" or og_image_path.endswith(".png"):
+        cr: float = os.path.getsize(og_image_path) / os.path.getsize(encoded_path)
+    elif encoded_extension in ("webp", "avif") and og_image_path.endswith(".apng"):
+        frames_list = filter(
+                lambda file: file.endswith(encoded_extension),
+                os.listdir(DATASET_COMPRESSED_PATH)
+            )
+        cr = os.path.getsize(og_image_path) / np.sum(
+            [os.path.getsize(os.path.abspath(DATASET_COMPRESSED_PATH+frame)) for frame in frames_list]
+        )
+    else:
+        pass  # TODO print program variables
+        raise AssertionError("Bad state")
 
     match encoded_extension:
         case "jxl":
 
-            decoded_path: str = target_image.replace("jxl", decoded_extension)
+            decoded_path: str = encoded_path.replace("jxl", decoded_extension)
 
             # Construct decoding command
-            command: str = f"djxl {target_image} {decoded_path}"
+            command = construct_djxl(decoded_path, encoded_path)
 
             dt = timed_command(command)
 
@@ -232,35 +199,47 @@ def decode_compare(target_image: str) -> Tuple[float, float, float, float, float
         case "avif":
 
             # Same directory, same name, .png
-            decoded_path: str = target_image.replace("avif", decoded_extension)
+            decoded_path: str = encoded_path.replace("avif", decoded_extension)
 
-            # Construct decoding command
-            command: str = f"avif_decode {target_image} {decoded_path}"
+            if og_image_path.endswith(".apng"):
+                dt = custom_multiframe_decoding(decoded_path, encoded_extension)
+            elif og_image_path.endswith(".png"):
+                # Construct decoding command
+                command = construct_davif(decoded_path, encoded_path)
 
-            dt = timed_command(command)
+                dt = timed_command(command)
+            else:
+                raise AssertionError(f"Illegal input image format: '{og_image_path}'")
 
             # Compute decoding speed (MP/s)
             ds = pixels / (dt * 1e6)
 
-            og_channels = int(os.path.basename(target_image).split("_")[SAMPLES_PER_PIXEL])
-            if og_channels == 1:
+            og_channels = dataset_img_info(encoded_path, SAMPLES_PER_PIXEL)
+            if og_channels == "1":
+                # AVIF output is always RGB/YCbCr
                 transcode_gray(decoded_path)
 
         case "webp":
 
-            decoded_path: str = target_image.replace("webp", decoded_extension)
+            decoded_path: str = encoded_path.replace("webp", decoded_extension)
 
-            # Construct decoding command
-            additional_options = "-tiff" if decoded_path.endswith("tiff") else ""
-            command: str = f"dwebp -v {target_image} {additional_options} -o {decoded_path}"
+            if og_image_path.endswith(".apng"):
+                # Execute decode command for all frames and collect DTs
+                dt = custom_multiframe_decoding(decoded_path, encoded_extension)
 
-            dt = timed_command(command)
+            elif encoded_path.endswith(".png"):
+                # Construct decoding command
+                command = construct_dwebp(decoded_path, encoded_path)
+
+                dt = timed_command(command)
+            else:
+                raise AssertionError(f"Illegal input image format: '{encoded_path}'")
 
             # Compute decoding speed (MP/s)
             ds = pixels / (dt * 1e6)
 
-            og_channels = int(os.path.basename(target_image).split("_")[SAMPLES_PER_PIXEL])
-            if og_channels == 1:
+            og_channels = dataset_img_info(encoded_path, SAMPLES_PER_PIXEL)
+            if og_channels == "1":
                 transcode_gray(decoded_path)
 
         case _:
@@ -268,8 +247,8 @@ def decode_compare(target_image: str) -> Tuple[float, float, float, float, float
 
     # Read the output images w/ opencv
     if decoded_path.endswith("apng"):
-        decoded_image = util.read_apng(decoded_path)
-        og_image = util.read_apng(og_image_path)
+        decoded_image = custom_apng.read_apng(decoded_path)
+        og_image = custom_apng.read_apng(og_image_path)
     else:
         decoded_image = cv2.imread(decoded_path, cv2.IMREAD_UNCHANGED)
         og_image = cv2.imread(og_image_path, cv2.IMREAD_UNCHANGED)
@@ -282,83 +261,60 @@ def decode_compare(target_image: str) -> Tuple[float, float, float, float, float
     return cr, ds, mse, psnr, ssim
 
 
-def transcode_gray(decoded_path):
-    # Cavif's .avif files only store in RGB/YCbCr format
-    img_gray = cv2.imread(decoded_path, cv2.IMREAD_GRAYSCALE)
-    assert img_gray is not None, f"Error reading decode output: {decoded_path}"
-    assert cv2.imwrite(decoded_path, img_gray) is True, "Error writing" \
-                                                        "gray version for rgb (gray original) image."
+def custom_multiframe_decoding(decoded_path, encoded_extension):
+    """Decodes all frames present in the dataset_compressed folder and outputs apng
 
-
-def extract_jxl_cs(stderr: bytes) -> str:
-    """ Extracts compression speed from a cjxl output
-
-    @param stderr: Console output
-    @return: Compression speed, in MP/s
+    @param decoded_path: APNG output file name
+    @param encoded_extension: reference to which codec is being used
+    @return: Sum of all frames' decoding time
     """
+    print("Custom decoding multi-frame image.")
 
-    # Find decoding speed in the output pool
-    ds = re.findall(r"\d+.\d+ MP/s", str(stderr))[1][:-5]
-    return ds
+    match encoded_extension:
+        case "avif":
+            custom_command: Callable[[str, str], str] = construct_davif
+        case "webp":
+            custom_command = construct_dwebp
+        case _:
+            raise AssertionError(f"Illegal format used: '{encoded_extension}'")
 
+    # Execute decode command for all frames and collect DTs
+    dt = 0
+    frame_names: list[str] = []
+    for i, frame in enumerate(os.listdir(DATASET_COMPRESSED_PATH)):
+        print(f"Decoded frame {i}")
+        frame_names.append(
+            DATASET_COMPRESSED_PATH + frame.replace(f".{encoded_extension}", ".png")
+        )
+        dt += timed_command(
+            custom_command(decoded_path=frame_names[-1], input_path=DATASET_COMPRESSED_PATH+frame)
+        )
+    # Staple output png frames
+    assert custom_apng.staple_pngs(decoded_path, *frame_names) is True, "Error joining PNGs"
 
-def extract_webp_ct(stderr: bytes) -> float:
-    """ Extracts compression speed from a cjxl output
-
-    @param stderr: Console output
-    @return: Compression speed, in MP/s
-    """
-
-    # Extract DT from output
-    dt: str = re.findall(r"Time to encode picture: \d+.\d+s", str(stderr))[0] \
-        .split("Time to encode picture: ")[-1]
-    # Cast to float
-    dt: float = float(dt[:-1])
     return dt
 
 
-def get_og_image(compressed, only_path: bool = False) -> np.ndarray | str:
-    """ Extract info on the original image given the compressed one
+def dataset_img_info(target_image: str, keyword: int) -> str:
+    """Extract the information present in the names of the pre-processed dataset
 
-    Note: if returned .multi, means that it is a multi-frame image.
-        This means there are multiple og images - their extensions are stored in parameters.MULTI_FRAME_EXT...
-
-    @param compressed: Path to compressed image
-    @param only_path: Optional flag - Set to true to return only the path to the og image
-    @return: Original image's path or contents
+    @param target_image:
+    @param keyword:
+    @return:
     """
-
-    # Get original lossless image
-    og_image_path = "".join(compressed.split("_compressed"))
-
-    og_number_frames = int(og_image_path.split(".")[0].split("_")[5])
-
-    og_image_path = "_".join(og_image_path.split("_")[:-1])
-    if og_number_frames == 1:
-        og_image_path += LOSSLESS_EXTENSION
-
-    if only_path is True:
-        return og_image_path
-    og_image = cv2.imread(og_image_path, cv2.IMREAD_UNCHANGED)
-    return og_image
+    return os.path.basename(target_image).split("_")[keyword]
 
 
-def image_to_dir(dataset_path: str, target_image: str) -> str:
-    """ Not used anymore
+def transcode_gray(img_path):
+    """Transcodes an image to gray using opencv
 
-    @param dataset_path: Path to the dataset folder (dataset for compressed is a sibling folder)
-    @param target_image: Path to the image from the original dataset
-    @return: Path to the folder in the dataset_compressed where the compressed form of
-        target_image should be stored
+    @param img_path: Path to the image to be transcoded
     """
-    # Do a "cd ../dataset_compressed"
-    path = "/".join(os.path.abspath(dataset_path).split("/")[:-1]) + "/dataset_compressed"
-    # Return path + image.path.basename
-    folder = path + "/" + os.path.basename(target_image) + "/"
-    # Mkdir if folder does not exist
-    if not os.path.exists(folder):
-        os.system(f"mkdir {folder}")
-    return folder
+    # Cavif's .avif files only store in RGB/YCbCr format
+    img_gray = cv2.imread(img_path, cv2.IMREAD_GRAYSCALE)
+    assert img_gray is not None, f"Error reading decode output: {img_path}"
+    assert cv2.imwrite(img_path, img_gray) is True, "Error writing" \
+                                                    "gray version for rgb (gray original) image."
 
 
 def bulk_compress(jxl: bool = True, avif: bool = True, webp: bool = True):
@@ -389,7 +345,7 @@ def bulk_compress(jxl: bool = True, avif: bool = True, webp: bool = True):
 
     # Set quality parameters to be used in compression
     # How many configurations are expected (evenly spaced in the range)
-    spread: int = 5
+    spread: int = 2
     quality_param_jxl: np.ndarray = np.linspace(.0, 3.0, spread)
     quality_param_avif = range(1, 101, int(100 / spread))
     quality_param_webp = range(1, 101, int(100 / spread))
@@ -430,7 +386,7 @@ def bulk_compress(jxl: bool = True, avif: bool = True, webp: bool = True):
                                     output_path=output_path)
 
                     # Decode and collect stats to stats df
-                    stats = finalize(cs, outfile_name, output_path, stats)
+                    stats = finalize(cs, outfile_name, output_path, stats, DATASET_PATH+target_image)
 
                     # Print when finished
                     print("Done!")
@@ -439,7 +395,7 @@ def bulk_compress(jxl: bool = True, avif: bool = True, webp: bool = True):
     if avif is True:
         for target_image in image_list:
 
-            if not target_image.endswith(".png"):
+            if not any([target_image.endswith(accepted) for accepted in (".png", ".apng")]):
                 continue
 
             for quality in quality_param_avif:
@@ -451,14 +407,13 @@ def bulk_compress(jxl: bool = True, avif: bool = True, webp: bool = True):
                     )
 
                     # Print the progress being made
-                    print(f"Started analysing image \"{outfile_name}\"...", end="")
+                    print(f"Started analysing image \"{outfile_name}\"", end="...")
 
-                    # Add wildcard for now because the extensions are missing
                     cs = encode_avif(target_image=DATASET_PATH + target_image,
                                      quality=quality, speed=speed, output_path=output_path)
 
                     # Decode and collect stats to stats df
-                    stats = finalize(cs, outfile_name, output_path, stats)
+                    stats = finalize(cs, outfile_name, output_path, stats, DATASET_PATH+target_image)
 
                     # Print when finished
                     print("Done!")
@@ -467,7 +422,7 @@ def bulk_compress(jxl: bool = True, avif: bool = True, webp: bool = True):
     if webp is True:
         for target_image in image_list:
 
-            if not target_image.endswith(".png"):
+            if not any([target_image.endswith(accepted) for accepted in (".png", ".apng")]):
                 continue
 
             for quality in quality_param_webp:
@@ -486,7 +441,7 @@ def bulk_compress(jxl: bool = True, avif: bool = True, webp: bool = True):
                                      quality=quality, effort=effort, output_path=output_path)
 
                     # Decode and collect stats to stats df
-                    stats = finalize(cs, outfile_name, output_path, stats)
+                    stats = finalize(cs, outfile_name, output_path, stats, DATASET_PATH+target_image)
 
                     # Print when finished
                     print("Done!")
@@ -498,41 +453,20 @@ def bulk_compress(jxl: bool = True, avif: bool = True, webp: bool = True):
     )
 
 
-def original_basename(intended_abs_filepath: str) -> str:
-    """Get an original filename given the absolute path
-
-    Example - give path/to/filename.txt -> it already exists -> return path/to/filename_1.txt
-
-    @param intended_abs_filepath: Absolute path to a file not yet written (w/o the file's extension)
-    @return: Same path, with basename of the file changed to an original one
-    """
-    # Separate path from extension
-    extension: str = intended_abs_filepath.split(".")[-1]
-    intended_abs_filepath: str = ".".join(intended_abs_filepath.split(".")[:-1])
-
-    suffix: str = ""
-    counter: int = 0
-
-    while os.path.exists(f"{intended_abs_filepath + suffix}.{extension}"):
-        counter += 1
-        suffix = f"_{counter}"
-
-    return f"{intended_abs_filepath + suffix}.{extension}"
-
-
-def finalize(cs: float, outfile_name: str, output_path: str, stats: pd.DataFrame) -> pd.DataFrame:
+def finalize(cs: float, outfile_name: str, encoded_path: str, stats: pd.DataFrame, og_img_path: str) -> pd.DataFrame:
     """Decode, collect eval data and remove compressed image.
 
     Decodes the target image file, deletes it and saves metadata to the provided dataframe
 
+    @param og_img_path: Path to the original image
     @param cs: Compression time of the provided compressed image file
     @param outfile_name: Basename of the provided file (compressed image)
-    @param output_path: Path to the provided file (compressed image)
+    @param encoded_path: Path to the provided file (compressed image)
     @param stats: Dataframe holding the data regarding the compressions
     @return: Updated Dataframe
     """
-    cr, ds, mse, psnr, ssim = decode_compare(output_path)
-    # Remove generated (png and jxl) images
+    cr, ds, mse, psnr, ssim = decode_compare(encoded_path, og_img_path)
+    # Remove generated (png and jxl/avif/webp) images
     rm_encoded()
     # Append new stats do dataframe
     row = pd.DataFrame(
@@ -542,15 +476,7 @@ def finalize(cs: float, outfile_name: str, output_path: str, stats: pd.DataFrame
     return stats
 
 
-def rm_encoded():
-    """Removes compressed files from a previous (probably unsuccessful) execution
-
-    """
-    for file in os.listdir(DATASET_COMPRESSED_PATH):
-        os.remove(os.path.abspath(DATASET_COMPRESSED_PATH + file))
-
-
-def get_output_path(dataset_path: str, target_image: str, effort: int, quality: float, format_: str) -> Tuple[str, str]:
+def get_output_path(dataset_path: str, target_image: str, effort: int, quality: float, format_: str) -> tuple[str, str]:
     """ Compute the output path of the compressed version of the target image.
 
     @param dataset_path: Dataset containing the target image.
@@ -583,7 +509,7 @@ def squeeze_data():
     df = pd.read_csv(PROCEDURE_RESULTS_FILE + ".csv")
 
     # Aggregate the results to a dict
-    resume: Dict[str, Dict[str, Dict[str, Dict[str, float]]]] = dict()
+    resume: dict[str, dict[str, dict[str, dict[str, float]]]] = dict()
     # df["filename"] but without the "modality_bodypart_" part
     settings_list: list = [elem.split("_")[-1] for elem in df["filename"]]
     # df["filename"] but without the "modality_bodypart_setting" part
@@ -626,5 +552,5 @@ if __name__ == '__main__':
 
     rm_encoded()
 
-    bulk_compress(jxl=True, avif=True, webp=True)
+    bulk_compress(jxl=False, avif=True, webp=True)
     squeeze_data()

--- a/util.py
+++ b/util.py
@@ -3,68 +3,176 @@
 """
 
 import os
+import time
+from subprocess import Popen, PIPE
 
 import cv2
-import numpy as np
-from apng import APNG, PNG
-from numpy import ndarray
+
+from custom_apng import get_apng_frames_resolution, get_apng_depth
+from parameters import DATASET_COMPRESSED_PATH
 
 
-def get_apng_frames_resolution(filename: str) -> tuple[int, int]:
+def construct_djxl(decoded_path, target_image):
+    """Creates the command for decoding an image to jxl
+
+    Given the provided configurations
+
+    @param decoded_path: Output path
+    @param target_image: Input path
+    @return: Command
     """
 
-    @param filename: APNG image file name
-    @return: height, width
+    return f"djxl {target_image} {decoded_path}"
+
+
+def construct_davif(decoded_path: str, input_path: str):
+    """Creates the command for decoding an image from avif
+
+    Given the provided configurations
+
+    @param decoded_path: Output path
+    @param input_path: Input path
+    @return: Command
+    """
+    command: str = f"avif_decode {input_path} {decoded_path}"
+    return command
+
+
+def construct_dwebp(decoded_path: str, target_image: str, additional_options: str = ""):
+    """Creates the command for decoding an image from webp
+
+    Given the provided configurations
+
+    @param additional_options: More options
+    @param decoded_path: Output path
+    @param target_image: Input path
+    @return: Command
+    """
+    command: str = f"dwebp -v {target_image} {additional_options} -o {decoded_path}"
+    return command
+
+
+def construct_cwebp(effort, output_path, quality, target_image):
+    """Creates the command for encoding an image to webp
+
+    Given the provided configurations
+
+    @param effort: Effort setting
+    @param output_path: Output
+    @param quality: Quality setting
+    @param target_image: Input
+    @return: Void
+    """
+    return f"cwebp -quiet -v -q {quality} -m {effort} {target_image} -o {output_path}"
+
+
+def construct_cavif(output_path, quality, speed, target_image):
+    """Creates the command for encoding an image to avif
+
+    Given the provided configurations
+
+    @param output_path: Output
+    @param quality: Quality setting
+    @param speed: Effort setting
+    @param target_image: Input
+    @return: Void
+    """
+    command: str = f"cavif -o {output_path} " \
+                   f"--quality {quality} --speed {speed} --quiet " \
+                   f"{os.path.abspath(target_image)}"
+    return command
+
+
+def construct_cjxl(distance, effort, output_path, target_image):
+    """Creates the command for encoding an image to jxl
+
+    Given the provided configurations
+
+    @param distance: Quality setting
+    @param effort: Effort setting
+    @param output_path: Output
+    @param target_image: Input
+    @return: Void
+    """
+    command: str = f"cjxl {target_image} {output_path} " \
+                   f"--distance={distance} --effort={effort} --quiet"
+    return command
+
+
+def timed_command(stdin: str) -> float:
+    """Runs a given command on a subshell and records its execution time
+
+    Note: Execution timeout implemented to 60 seconds
+
+    @param stdin: Used to run the subshell command
+    @return: Time it took for the command to run (in seconds)
+    """
+    # Execute command and time the CT
+    start = time.time()
+    p = Popen(stdin, shell=True, stdout=PIPE, stderr=PIPE)
+    _, stderr = p.communicate(timeout=120)
+    ct = time.time() - start  # or extract_webp_ct(stderr)
+    # Check for errors
+    return_code: int = p.returncode
+    if return_code != 0:
+        print(f"Error code {return_code}, executing:"
+              f"\nStdIn -> {stdin}"
+              f"\nStdErr -> {stderr}")
+        exit(1)
+
+    return ct
+
+
+def total_pixels(target_image: str) -> int:
+    """Counts the number of pixels on an image
+
+    Count method: height * height
+
+    @param target_image: Input image path
+    @return: Number of pixels
     """
 
-    apng_img = APNG.open(filename)
+    # Parameter checking
+    assert os.path.exists(target_image), f"Image at \"{target_image}\" does not exist!"
 
-    first_frame, _ = apng_img.frames[0]
+    # Extract resolution
+    if target_image.endswith("apng"):
+        height, width = get_apng_frames_resolution(target_image)
+        depth = get_apng_depth(target_image)
 
-    tmp: ndarray = read_apng_frame(first_frame)
+        return height * width * depth
 
-    return tmp.shape[:2]
+    height, width = cv2.imread(target_image).shape[:2]
+    # Number of pixels in the image
+    pixels = height * width
+    return pixels
 
 
-def read_apng_frame(frame: PNG) -> ndarray:
+def original_basename(intended_abs_filepath: str) -> str:
+    """Get an original filename given the absolute path
+
+    Example - give path/to/filename.txt -> it already exists -> return path/to/filename_1.txt
+
+    @param intended_abs_filepath: Absolute path to a file not yet written (w/o the file's extension)
+    @return: Same path, with basename of the file changed to an original one
     """
+    # Separate path from extension
+    extension: str = intended_abs_filepath.split(".")[-1]
+    intended_abs_filepath: str = ".".join(intended_abs_filepath.split(".")[:-1])
 
-    @param frame: Single frame from an APNG
-    @return:
+    suffix: str = ""
+    counter: int = 0
+
+    while os.path.exists(f"{intended_abs_filepath + suffix}.{extension}"):
+        counter += 1
+        suffix = f"_{counter}"
+
+    return f"{intended_abs_filepath + suffix}.{extension}"
+
+
+def rm_encoded():
+    """Removes compressed files from a previous (probably unsuccessful) execution
+
     """
-    tmp_fname = "tmp.png"
-    frame.save(tmp_fname)
-    tmp = cv2.imread(tmp_fname, cv2.IMREAD_UNCHANGED)
-    os.remove(tmp_fname)
-    return tmp
-
-
-def to_np_array(apng_img: APNG) -> ndarray:
-    """
-
-    @param apng_img: APNG image parsed object
-    @return: Numpy ndarray with the images contents
-    """
-    frames_arr: list[ndarray] = [read_apng_frame(frame) for frame, _ in apng_img.frames]
-
-    return np.array(frames_arr)
-
-
-def read_apng(filename: str) -> ndarray:
-    """
-
-    @param filename: .apng image file name - E.g.: "image.png"
-    @return: Numpy ndarray with the images contents
-    """
-    return to_np_array(
-        APNG.open(filename)
-    )
-
-
-def get_apng_depth(target_image: str) -> int:
-    """
-
-    @param target_image: Image to be evaluated
-    @return: Number of frames in the multi-frame image
-    """
-    return len(APNG.open(target_image).frames)
+    for file in os.listdir(DATASET_COMPRESSED_PATH):
+        os.remove(os.path.abspath(DATASET_COMPRESSED_PATH + file))

--- a/util.py
+++ b/util.py
@@ -38,17 +38,17 @@ def construct_davif(decoded_path: str, input_path: str):
     return command
 
 
-def construct_dwebp(decoded_path: str, target_image: str, additional_options: str = ""):
+def construct_dwebp(decoded_path: str, input_path: str, additional_options: str = ""):
     """Creates the command for decoding an image from webp
 
     Given the provided configurations
 
     @param additional_options: More options
     @param decoded_path: Output path
-    @param target_image: Input path
+    @param input_path: Input path
     @return: Command
     """
-    command: str = f"dwebp -v {target_image} {additional_options} -o {decoded_path}"
+    command: str = f"dwebp -v {input_path} {additional_options} -o {decoded_path}"
     return command
 
 


### PR DESCRIPTION
Since webp/avif don't support >8 bits per sample multiframe images, this feature separates each frame as a single image, and bundles (mean, for example) metrics of all frames into the whole image.